### PR TITLE
Add option to just use QUIC

### DIFF
--- a/draft-tjohn-quic-multipath-dmtp.md
+++ b/draft-tjohn-quic-multipath-dmtp.md
@@ -86,7 +86,7 @@ Within this document:
 
 # Design Overview
 
-## Integrating Deadline-Aware Streams into QUIC-MULTIPATH {#features}
+## Integrating Deadline-Aware Streams into QUIC-MULTIPATH/QUIC {#features}
 
 Our design goal is to extend {{QUIC-MULTIPATH}} and {{QUIC}} respectively with minimal changes. The proposed extension enables endpoints to signal a stream's deadline. Implementations that support deadline-aware streams MUST support:
 

--- a/draft-tjohn-quic-multipath-dmtp.md
+++ b/draft-tjohn-quic-multipath-dmtp.md
@@ -47,23 +47,25 @@ informative:
 
 --- abstract
 
-This document proposes the Deadline-aware Multipath Transport Protocol (DMTP) concept as an extension to the Multipath Extension for QUIC (QUIC-MULTIPATH). This extension aims to support data streams with strict latency requirements by enabling the signaling of a stream's deadline and by combining multipath scheduling, congestion control adaptations, and optional forward error correction (FEC). Moreover, DMTP leverages QUIC-MULTIPATH's path identifiers to distinguish different end-to-end paths as they may be offered in a Path Aware Network (PAN) such as SCION. This allows an application to select its preferred paths while maintaining interoperability with standard QUIC-MULTIPATH endpoints. In combination, DMTP enables endpoints to exchange and schedule deadline-aware streams across multiple network paths.
+This document proposes the Deadline-aware Multipath Transport Protocol (DMTP) concept as an extension to the Multipath Extension for QUIC (QUIC-MULTIPATH) as well as QUIC itself. This extension aims to support data streams with strict latency requirements by enabling the signaling of a stream's deadline and ideally by combining multipath scheduling, congestion control adaptations, and optional forward error correction (FEC). Moreover, DMTP leverages QUIC-MULTIPATH's path identifiers to distinguish different end-to-end paths as they may be offered in a Path Aware Network (PAN) such as SCION. This allows an application to select its preferred paths while maintaining interoperability with standard QUIC-MULTIPATH endpoints. In combination, DMTP enables endpoints to exchange and schedule deadline-aware streams across multiple network paths. Additionally, this proposal also maintains compatibility with QUIC itself, in order to deliver its benefits – albeit with limited effectiveness – even in scenarios where only a single path can or should be used.
 
 --- middle
 
 # Introduction
 
-The Multipath Extension for QUIC {{QUIC-MULTIPATH}} enhances performance by simultaneously utilizing multiple paths between endpoints. However, QUIC-MULTIPATH currently lacks support for strict deadline requirements of real-time applications such as teleoperation, live video streaming, or interactive gaming, which are becoming increasingly important. These applications demand low and bounded latency, and can often tolerate no or only partial retransmission of missing data.
+The Multipath Extension for QUIC {{QUIC-MULTIPATH}} enhances performance by simultaneously utilizing multiple paths between endpoints. However, both {{QUIC}} and {{QUIC-MULTIPATH}} currently lack support for strict deadline requirements of real-time applications such as teleoperation, live video streaming, or interactive gaming, which are becoming increasingly important. These applications demand low and bounded latency, and can often tolerate no or only partial retransmission of missing data.
 
-Previous work on deadline-aware protocols for QUIC includes the Deadline-aware Transport Protocol {{QUIC-DTP}}, a single-path approach that introduced deadlines for streams but did not exploit multipath capabilities. Meanwhile, our DMTP {{DMTP}} approach allows to take advantage of multiple paths, combined with forward error correction (FEC) and intelligent retransmissions, to significantly increase the fraction of packets meeting their deadlines, especially in the presense of lossy or high-latency links.
+Previous work on deadline-aware protocols for {{QUIC}} includes the Deadline-aware Transport Protocol {{QUIC-DTP}}, a single-path-only approach that introduced deadlines for streams but did not exploit multipath capabilities. Meanwhile, our {{DMTP}} approach additionally allows taking advantage of multiple paths, combined with forward error correction (FEC) and intelligent retransmissions, to significantly increase the fraction of packets meeting their deadlines, especially in the presence of lossy or high-latency links.
 
-By integrating deadline-aware concepts into QUIC-MULTIPATH, we seek to enable:
+By integrating deadline-aware concepts into {{QUIC-MULTIPATH}}, we seek to enable:
 
 1. Multipath streams with Deadlines: Scheduling and transmitting data across multiple paths, with strict deadlines of streams driving scheduling decisions.
-2. Option for Path-Aware Networking: Support for path selection as offered in Path Aware Networks (e.g., {{SCION}}) by mapping each potential path to an QUIC-MULTIPATH path identifier.
+2. Option for Path-Aware Networking: Support for path selection as offered in Path Aware Networks (e.g., {{SCION}}) by mapping each potential path to an {{QUIC-MULTIPATH}} path identifier.
 3. Deadline-Based Retransmission / FEC: Combining optional adaptive FEC (such as {{QUIC-AFEC}}) and "smart" retransmissions only when there may still be time left to meet the deadline.
 
-This draft specifies a minimal set of protocol extensions for QUIC-MULTIPATH to exchange deadline information at the transport layer, so that endpoints can coordinate scheduling for multipath transmissions with strict time constraints. As the first version of our proposal, our goal is to gather community feedback and gauge interest to guide future refinements.
+Using the deadline-aware concepts of this proposal together with {{QUIC}} in a single-path scenario will still offer the advantage of deadline-based retransmissions / FEC but limit its effectiveness to the boundaries set by the available path.
+
+This draft specifies a minimal set of protocol extensions for {{QUIC-MULTIPATH}} respectively {{QUIC}} to exchange deadline information at the transport layer, so that endpoints can coordinate scheduling for multipath transmissions with strict time constraints. As the first version of our proposal, our goal is to gather community feedback and gauge interest to guide future refinements.
 
 ## Motivation and Applications
 
@@ -80,57 +82,61 @@ Real-time applications often produce data blocks (e.g., video frames or control 
 
 Within this document:
 - "Deadline-aware streams" refers to streams in which an application indicates a time by which data must be delivered, beyond which data is no longer useful.
-- "Path" aligns with the QUIC-MULTIPATH concept: each path is identified by a unique Path ID and it may reference a specific combination of source and destination IP:port tuples or multiple paths as they may be offered in a path aware network, as defined by {{RFC9473}}.
+- "Path" aligns with the {{QUIC-MULTIPATH}} concept: Each path is identified by a unique Path ID and it may reference a specific combination of source and destination IP:port tuples or multiple paths as they may be offered in a path aware network, as defined by {{RFC9473}}.
 
 # Design Overview
 
-## Integrating Deadline-Aware Streams into QUIC-MULTIPATH
+## Integrating Deadline-Aware Streams into QUIC-MULTIPATH {#features}
 
-Our design goal is to extend QUIC-MULTIPATH with minimal changes. The proposed extension enables endpoints to signal a stream's deadline. Implementations that support deadline-aware streams MUST implement:
+Our design goal is to extend {{QUIC-MULTIPATH}} and {{QUIC}} respectively with minimal changes. The proposed extension enables endpoints to signal a stream's deadline. Implementations that support deadline-aware streams MUST support:
+
+1. Packet Scheduling: Implement scheduling algorithms that:
+   - Prioritize packets from streams with earlier deadlines
+   - Account for path characteristics when making scheduling decisions
+   - Consider current congestion state of available paths
+
+2. Retransmission Control: Implement retransmission policies that:
+   - Evaluate whether retransmitted packets can meet remaining deadlines
+   - Skip retransmissions when deadlines cannot be met
+   - Consider path conditions when selecting retransmission paths when using {{QUIC-MULTIPATH}}
+
+3. Deadline Monitoring: Track deadline status and:
+   - Detect when deadlines cannot be met
+   - Signal deadline misses to the application layer
+   - Allow applications to specify handling of missed deadlines
+
+Additionally, Implementations supporting deadline-aware streams while using {{QUIC-MULTIPATH}} MUST feature:
 
 1. Path Selection: Select paths for transmitting frames, retransmissions and acknowledgements based on metrics relevant to meeting deadlines, including:
    - Path latency measurements
    - Estimation of available bandwidth
    - Observed packet loss rates
 
-2. Packet Scheduling: Implement scheduling algorithms that:
-   - Prioritize packets from streams with earlier deadlines
-   - Account for path characteristics when making scheduling decisions
-   - Consider current congestion state of available paths
+Implementations MAY also choose to support:
 
-3. Retransmission Control: Implement retransmission policies that:
-   - Evaluate whether retransmitted packets can meet remaining deadlines
-   - Skip retransmissions when deadlines cannot be met
-   - Consider path conditions when selecting retransmission paths
-
-4. Optional Forward Error Correction: MAY implement FEC mechanisms that:
+1. Optional Forward Error Correction: MAY implement FEC mechanisms that:
    - Reduce retransmission overhead for deadline-sensitive streams
    - Adapt FEC overhead based on path conditions
    - Apply FEC selectively based on stream requirements (e.g., stream priority)
 
-5. Deadline Monitoring: Track deadline status and:
-   - Detect when deadlines cannot be met
-   - Signal deadline misses to the application layer
-   - Allow applications to specify handling of missed deadlines
+### Extensions to QUIC-MULTIPATH/QUIC
 
-### Extensions to QUIC-MULTIPATH
-
-Our extensions build on {{QUIC-MULTIPATH}}'s multipath framework (e.g., paths, path IDs, and validation) and add only:
+Our extensions build on {{QUIC-MULTIPATH}}'s multipath framework (e.g., paths, path IDs, and validation). It will, however, also work with {{QUIC}}, be it with a reduced featureset (see {{features}}). This extension will add only:
 
 - A transport parameter to enable deadline-aware streams.
 - A DEADLINE_CONTROL frame to signal stream deadlines.
 - Optional support for a TIMESTAMP frame for improved per-path delay feedback.
 - Optional AFEC support via an extra transport parameter and two frames for source and repair symbol metadata.
 
-This preserves the original wire format, ensuring interoperability with {{QUIC-MULTIPATH}} endpoints that do not implement these extensions.
+This preserves the original wire format, ensuring interoperability with both {{QUIC-MULTIPATH}} and {{QUIC}} endpoints that do not implement these extensions.
 
 ## Support for Path-Aware Networks (PAN)
 
-When operating over a path-aware network, endpoints can discover and utilize multiple disjoint or partially disjoint paths. This can be provided, for example, by {{SCION}} or other architectures such as {{SR}}. In such an environment, a single source–destination address pair may yield multiple distinct end-to-end paths, each with unique performance characteristics (e.g., latency, loss rate). These paths can be exposed to the transport layer via distinct Path IDs in {{QUIC-MULTIPATH}}.
+When operating over a path-aware network in addition to {{QUIC-MULTIPATH}}, endpoints can discover and utilize multiple disjoint or partially disjoint paths. This can be provided, for example, by {{SCION}} or other architectures such as {{SR}}. In such an environment, a single source–destination address pair may yield multiple distinct end-to-end paths, each with unique performance characteristics (e.g., latency, loss rate). These paths can be exposed to the transport layer via distinct Path IDs in {{QUIC-MULTIPATH}}.
 
 This document does not prescribe how endpoints discover and enumerate available paths at the network layer. Rather, it assumes that a PAN can supply multiple viable routes between endpoints. Once discovered, each route is mapped to a unique Path ID, enabling the {{DMTP}} scheduling logic to treat them as distinct transport paths for deadline-aware streams.
 
-Multiple paths and path diversity provided by PAN enhance the effectiveness of {{DMTP}}'s scheduling, retransmission, and optional FEC mechanisms in meeting strict deadlines, making support for PAN essential to the design of the proposed extension.
+Multiple paths provided by {{QUIC-MULTIPATH}} on the one hand and path diversity provided by PAN on the other hand enhance the effectiveness of {{DMTP}}'s scheduling, retransmission, and optional FEC mechanisms in meeting strict deadlines, making support for PAN essential to the design of the proposed extension.
 
 ## Deadlines
 
@@ -143,7 +149,7 @@ To signal deadlines, endpoints use the DEADLINE_CONTROL frame (see {{deadline-co
 - Deadline Representation: Deadlines are represented as a relative time in milliseconds from the time the frame is sent.
 - Stream Association: A deadline applies to a specific stream identified by its Stream ID
 - Transport Behavior: Upon receiving a DEADLINE_CONTROL frame, the transport layer SHOULD attempt to schedule and retransmit packets carrying data for the specified stream to meet the indicated deadline.
-- Retransmissions and Scheduling: Endpoints MAY implement custom schedulers and congestion controllers optimized for deadline-aware traffic, such as those based on DMTP concepts.
+- Retransmissions and Scheduling: Endpoints MAY implement custom schedulers and congestion controllers optimized for deadline-aware traffic, such as those based on {{DMTP}} concepts.
 
 ### Handling Missed Deadline
 
@@ -159,29 +165,29 @@ The specific behavior is implementation-specific and MAY be configurable by the 
 
 When deadlines are tight and packet losses frequent, relying solely on retransmissions may cause data to miss its deadline. To mitigate this risk, this extension optionally uses Adaptive FEC (AFEC) as proposed in {{QUIC-AFEC}}. AFEC can reduce the need for retransmissions, particularly in networks with random or bursty loss characteristics.
 
-When using AFEC with {{QUIC-MULTIPATH}}, the Tag Type of the FEC_Tag MUST be set to 1 to indicate "Long Flow Usage". In turn, both source symbol packets and repair symbol packets MUST carry the FEC_Tag frame so that repair packets can be correctly matched to their corresponding source packets across different paths.
+When using AFEC with {{QUIC-MULTIPATH}}, the Tag Type of the FEC_Tag MUST be set to 1 to indicate "Long Flow Usage". In turn, both source symbol packets and repair symbol packets MUST carry the FEC_Tag frame so that repair packets can be correctly matched to their corresponding source packets across different paths. Such a constraint is not needed in an environment that uses {{QUIC}}.
 
 If multiple paths are available, FEC repair packets SHOULD be sent over a path different from the one carrying the source data. This de-correlates losses and increases the likelihood that repair symbols arrive even if other paths experience congestion or packet loss. The coding rate (i.e., the ratio of repair symbols to source symbols) MAY be configured on a per-stream basis, depending on the stream's tolerance for overhead versus its deadline sensitivity.
 
 ## Smart Retransmissions
 
-Smart retransmissions in a deadline-aware context mean that lost frames are only retransmitted if there is still enough time left to meet the deadline via one or more paths. The sender computes whether the frames can arrive on time, factoring in the path's estimated one-way delay or RTT. If not, the sender discards the frames rather than wasting congestion window or scheduling capacity.
+Smart retransmissions in a deadline-aware context mean that lost frames are only retransmitted if there is still enough time left to meet the deadline via one or – in case of a {{QUIC-MULTIPATH}} setup – more paths. The sender computes whether the frames can arrive on time, factoring in the path's estimated one-way delay or RTT. If not, the sender discards the frames rather than wasting congestion window or scheduling capacity.
 
 ## Path Metrics
 
-To schedule traffic effectively, the sender should gather:
+To schedule traffic effectively, the sender SHOULD gather:
 
-- One-Way Delays or RTT: For selecting the path(s) that can deliver data before the deadline.
+- When using {{QUIC-MULTIPATH}}: One-Way Delays or RTT for selecting the path(s) that can deliver data before the deadline.
 - Loss Rate: For deciding whether to apply adaptive FEC or more aggressive retransmissions.
 - Available Bandwidth: So that sending on path(s) with insufficient capacity does not cause additional delay.
 
 ### Per Path Delay
 
-A crucial metric for DMTP is the one-way or round-trip delay of each path. This is used to decide whether a new or retransmitted packet can arrive before its deadline. In a path-aware network, the one-way delay might be advertised or inferred from routing information. Otherwise, endpoints measure RTT or one-way delay themselves.
+A crucial metric for DMTP is the one-way or round-trip delay of the available path(s). This is used to decide whether a new or retransmitted packet can arrive before its deadline. In a path-aware network, the one-way delay might be advertised or inferred from routing information. Otherwise, endpoints measure RTT or one-way delay themselves.
 
-For accurate one-way delay measurements, endpoints MAY use synchronized clocks; if full clock sync is not feasible, a fallback to round-trip time measurements is still acceptable. For improved delay tracking the additional fields for the receive timestampt of the ACK_EXTENDED frame as proposed in {{QUIC-RECEIVE-TS}} is used.
+For accurate one-way delay measurements, endpoints MAY use synchronized clocks; if full clock sync is not feasible, a fallback to round-trip time measurements is still acceptable. For improved delay tracking, the additional fields for the receive timestamp of the ACK_EXTENDED frame as proposed in {{QUIC-RECEIVE-TS}} is used.
 
-If endpoints have agreed on the usage of the ACK_EXTENDED frame with the additional receive timestamp fields (Bit 1 of extended_ack_features transport parameter), packets containing a PING (type=0x01) frame MUST be acknowledged on the same path that the packet was received on.
+In a {{QUIC-MULTIPATH}} environment, if endpoints have agreed on the usage of the ACK_EXTENDED frame with the additional receive timestamp fields (Bit 1 of extended_ack_features transport parameter), packets containing a PING (type=0x01) frame MUST be acknowledged on the same path that the packet was received on.
 
 ### Gathering Path Metrics
 
@@ -190,9 +196,9 @@ If endpoints have agreed on the usage of the ACK_EXTENDED frame with the additio
 3. Path Measurement Frames: This draft uses the ACK_EXTENDED frame ({{QUIC-RECEIVE-TS}}) for deeper path measurements, including timestamps of packet receipts to estimate per path one-way delay.
 4. Congestion windows, RTT estimates, and packet loss detection from {{QUIC-MULTIPATH}}'s standard loss recovery can inform scheduling.
 
-# Extension to QUIC-MULTIPATH
+# Extension to QUIC-MULTIPATH/QUIC
 
-This extension builds upon {{QUIC-MULTIPATH}}. Below we list the protocol additions and modifications. Unless otherwise noted, all rules of QUIC-MULTIPATH remain.
+This extension builds upon {{QUIC-MULTIPATH}} and {{QUIC}} respectively. Below we list the protocol additions and modifications. Unless otherwise noted, all rules of {{QUIC-MULTIPATH}} or {{QUIC}} remain.
 
 ## Handshake Negotiation and Transport Parameter {#transport-parameter}
 
@@ -248,12 +254,12 @@ This extension retains all the security features and considerations of {{QUIC}},
 Nevertheless, it introduces additional considerations:
 
 - Deadline Signaling: Knowledge of deadlines or priorities may be sensitive if it reveals application timing patterns or critical data intervals. Implementations SHOULD carefully handle metadata (e.g., by encrypting frames in 1-RTT packets).
-- Resource Exhaustion and Flooding: The ability to manage multiple concurrent paths and to schedule or drop data based on deadlines must not weaken QUIC's anti-amplification measures. Endpoints MUST still follow QUIC path validation procedures, ensuring that an attacker cannot exploit deadline-aware frames to amplify traffic.
-- When employing TIMESTAMP frames for one-way delay measurement with clock synchronization, the clock synchronization must also be secured. Otherwise, an attacker injecting false timestamps could mislead scheduling. Endpoints that rely heavily on these measurements should be aware of that risk and possibly cross-check with measured RTT or other heuristics.
+- Resource Exhaustion and Flooding: The ability to manage multiple concurrent paths and to schedule or drop data based on deadlines must not weaken {{QUIC}}'s anti-amplification measures. Endpoints MUST still follow {{QUIC}} path validation procedures, ensuring that an attacker cannot exploit deadline-aware frames to amplify traffic.
+- When employing ACK_EXTENDED frames for one-way delay measurement with clock synchronization, the clock synchronization must also be secured. Otherwise, an attacker injecting false timestamps could mislead scheduling. Endpoints that rely heavily on these measurements should be aware of that risk and possibly cross-check with measured RTT or other heuristics.
 
 # IANA Considerations
 
-This document defines a new transport parameter for the negotiation of enable multiple paths for QUIC, and two new frame types. The draft defines provisional values for experiments.
+This document defines a new transport parameter for the negotiation of deadline-aware streams for {{QUIC-MULTIPATH}} or {{QUIC}}, and one new frame type. The draft defines provisional values for experiments.
 
 The following entry in {{transport-parameters}} should be added to the "QUIC Transport Parameters" registry under the "QUIC Protocol" heading.
 
@@ -275,4 +281,4 @@ TBD (1)                                            | DEADLINE_CONTROL    | {{dea
 # Acknowledgments
 {:numbered="false"}
 
-The authors thank the QUIC working group and the designers of both {{QUIC-MULTIPATH}} and {{QUIC-DTP}} for paving the way for deadline-aware features in QUIC. The concept of scheduling data with deadlines over multiple paths builds on numerous discussions around partial reliability, adaptive FEC, and optimal path selection.
+The authors thank the QUIC working group and the designers of {{QUIC}}, {{QUIC-MULTIPATH}} and {{QUIC-DTP}} for paving the way for deadline-aware features in QUIC. The concept of scheduling data with deadlines over multiple paths builds on numerous discussions around partial reliability, adaptive FEC, and optimal path selection.

--- a/draft-tjohn-quic-multipath-dmtp.md
+++ b/draft-tjohn-quic-multipath-dmtp.md
@@ -35,7 +35,6 @@ normative:
    QUIC-MULTIPATH: I-D.draft-ietf-quic-multipath
    QUIC-AFEC: I-D.draft-dmoskvitin-quic-adaptive-fec
    QUIC-RECEIVE-TS: I-D.draft-smith-quic-receive-ts
-   RFC3339:
    RFC9473:
 
 informative:
@@ -65,7 +64,7 @@ By integrating deadline-aware concepts into {{QUIC-MULTIPATH}}, we seek to enabl
 
 Using the deadline-aware concepts of this proposal together with {{QUIC}} in a single-path scenario will still offer the advantage of deadline-based retransmissions / FEC but limit its effectiveness to the boundaries set by the available path.
 
-This draft specifies a minimal set of protocol extensions for {{QUIC-MULTIPATH}} respectively {{QUIC}} to exchange deadline information at the transport layer, so that endpoints can coordinate scheduling for multipath transmissions with strict time constraints. As the first version of our proposal, our goal is to gather community feedback and gauge interest to guide future refinements.
+This draft specifies a minimal set of protocol extensions for {{QUIC-MULTIPATH}} and {{QUIC}} respectively to exchange deadline information at the transport layer, so that endpoints can coordinate scheduling for multipath transmissions with strict time constraints. As the first version of our proposal, our goal is to gather community feedback and gauge interest to guide future refinements.
 
 ## Motivation and Applications
 
@@ -125,7 +124,7 @@ Our extensions build on {{QUIC-MULTIPATH}}'s multipath framework (e.g., paths, p
 
 - A transport parameter to enable deadline-aware streams.
 - A DEADLINE_CONTROL frame to signal stream deadlines.
-- Optional support for a TIMESTAMP frame for improved per-path delay feedback.
+- Optional support for a ACK_EXTENDED frame for improved per-path delay feedback.
 - Optional AFEC support via an extra transport parameter and two frames for source and repair symbol metadata.
 
 This preserves the original wire format, ensuring interoperability with both {{QUIC-MULTIPATH}} and {{QUIC}} endpoints that do not implement these extensions.


### PR DESCRIPTION
As the people from the mailing list proposed, I rephrased the draft so that it is also applicable to QUIC and not only to QUIC-MULTIPATH.